### PR TITLE
Implement fiveoutofnine chess NFT `tokenURI` proxy endpoint

### DIFF
--- a/lib/services/supabase.ts
+++ b/lib/services/supabase.ts
@@ -2,10 +2,16 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
 
 /**
  * Client-exposed Supabase client.
  */
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+/**
+ * Server-only Supabase client.
+ */
+export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
 export default supabase;

--- a/lib/services/supabase.ts
+++ b/lib/services/supabase.ts
@@ -2,16 +2,10 @@ import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-const supabaseServiceKey = process.env.SUPABASE_SERVICE_KEY;
 
 /**
  * Client-exposed Supabase client.
  */
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
-
-/**
- * Server-only Supabase client.
- */
-export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceKey);
 
 export default supabase;

--- a/lib/types/chess.ts
+++ b/lib/types/chess.ts
@@ -20,3 +20,29 @@ export type ChessFeature = {
   contractMove: { from: number; to: number };
   boardAfterMove: string;
 };
+
+/**
+ * Type for the metadata returned by fiveoutofnine chess NFT's (an NFT deployed
+ * to
+ * [`0xB543F9043b387cE5B3d1F0d916E42D8eA2eBA2E0`](https://etherscan.io/address/0xb543f9043b387ce5b3d1f0d916e42d8ea2eba2e0)
+ * on Ethereum) `_tokenURI` function (internal helper function intended to
+ * generate the contents of what `tokenURI` should return on-chain).
+ * @param id Token ID of the NFT (note: in the format of
+ * `(gameId << 128) | (moveId)`).
+ * @param name Name of the NFT.
+ * @param description Description of the NFT. In this case, it is a description
+ * of the moves played by both the minter and the contract, formatted with
+ * markdown.
+ * @param animation_url URL to the animation of the NFT (i.e. the ``image'').
+ * @param attributes Attributes of the NFT.
+ */
+export type ChessNFTMetadata = {
+  id: number;
+  name: string;
+  description: string;
+  animation_url: string;
+  attributes: {
+    trait_type: string;
+    value: string;
+  }[];
+};

--- a/pages/api/chess/asset/[id].ts
+++ b/pages/api/chess/asset/[id].ts
@@ -22,7 +22,23 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   res.setHeader('Content-Type', 'text/html');
   // Cache response for 1 week, revalidate after 1 day.
   res.setHeader('cache-control', 'public, s-maxage=604800, stale-while-revalidate=86400');
-  res.status(200)
-    .send(`<script type="text/javascript">w=window;w.addEventListener('DOMContentLoaded',()=>{n=document.querySelector('section').style;n.transformOrigin='top left';a=()=>n.transform='scale('+w.innerWidth/1000+')';a();w.onresize=a});
-  </script>${Buffer.from(data.animation_url.substring(22), 'base64').toString()}`);
+  // The prepended script tag is to scale the animation to the window size. It
+  // is equivalent to the following:
+  // ```js
+  // window.addEventListener('DOMContentLoaded', () => {
+  //   const section = document.querySelector('section');
+  //   section.style.transformOrigin = 'top left';
+  //   const scale = () => section.style.transform = 'scale(' + window.innerWidth / 1000 + ')';
+  //   scale();
+  //   window.onresize = scale;
+  // });
+  // ```
+  res
+    .status(200)
+    .send(
+      `<script type="text/javascript">w=window;w.addEventListener('DOMContentLoaded',()=>{n=document.querySelector('section').style;n.transformOrigin='top left';a=()=>n.transform='scale('+w.innerWidth/1000+')';a();w.onresize=a});</script>${Buffer.from(
+        data.animation_url.substring(22),
+        'base64',
+      ).toString()}`,
+    );
 }

--- a/pages/api/chess/asset/[id].ts
+++ b/pages/api/chess/asset/[id].ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { idSchema } from '@/lib/schemas';
+import supabase from '@/lib/services/supabase';
+import { validateQuery } from '@/lib/utils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<string>) {
+  const { id } = validateQuery(idSchema, req.query);
+
+  // Fetch image.
+  const { data, status, error } = await supabase
+    .from('chess_nft_metadata')
+    .select('animation_url')
+    .eq('id', id)
+    .single();
+
+  if ((error && status !== 406) || !data) {
+    res.status(404).send('Not found.');
+    return;
+  }
+
+  res.setHeader('Content-Type', 'text/html');
+  // Cache response for 1 week, revalidate after 1 day.
+  res.setHeader('cache-control', 'public, s-maxage=604800, stale-while-revalidate=86400');
+  res.status(200)
+    .send(`<script type="text/javascript">w=window;w.addEventListener('DOMContentLoaded',()=>{n=document.querySelector('section').style;n.transformOrigin='top left';a=()=>n.transform='scale('+w.innerWidth/1000+')';a();w.onresize=a});
+  </script>${Buffer.from(data.animation_url.substring(22), 'base64').toString()}`);
+}

--- a/pages/api/chess/feature/[id].ts
+++ b/pages/api/chess/feature/[id].ts
@@ -1,18 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-import { BigNumber } from 'ethers';
-import { createPublicClient, http } from 'viem';
-import { mainnet } from 'viem/chains';
-
 import { CHESS_NFT_FALLBACK, CHESS_NFTS } from '@/lib/constants/chess-nfts';
 import { idSchema } from '@/lib/schemas';
+import supabase from '@/lib/services/supabase';
 import type { ChessFeature } from '@/lib/types/chess';
 import { validateQuery } from '@/lib/utils';
-
-export const publicClient = createPublicClient({
-  chain: mainnet,
-  transport: http(),
-});
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse<ChessFeature>) {
   const { id } = validateQuery(idSchema, req.query);
@@ -25,23 +17,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
   const nft = CHESS_NFTS[id];
 
   // Fetch image.
-  const nftMetadata = await publicClient.readContract({
-    address: '0xB543F9043b387cE5B3d1F0d916E42D8eA2eBA2E0', // fiveoutofnine Chess NFT contract
-    abi: [
-      {
-        inputs: [{ internalType: 'uint256', name: '_tokenId', type: 'uint256' }],
-        name: '_tokenURI',
-        outputs: [{ internalType: 'string', name: '', type: 'string' }],
-        stateMutability: 'view',
-        type: 'function',
-      },
-    ],
-    functionName: '_tokenURI',
-    args: [BigNumber.from(id)],
-  });
-  const image = JSON.parse(Buffer.from(nftMetadata.substring(29), 'base64').toString())[
-    'animation_url'
-  ].substring(22);
+  const { data, status, error } = await supabase
+    .from('chess_nft_metadata')
+    .select('animation_url')
+    .eq('id', id)
+    .single();
+
+  if ((error && status !== 406) || !data) {
+    // Technically, this should error, but we return the fallback because this
+    // endpoint is just intended to display sample NFTs on the home page.
+    res.status(200).json(CHESS_NFT_FALLBACK);
+    return;
+  }
+
+  const image = data.animation_url.substring(22);
 
   // Cache response for 1 week, revalidate after 1 day.
   res.setHeader('cache-control', 'public, s-maxage=604800, stale-while-revalidate=86400');

--- a/pages/api/chess/token/[id].ts
+++ b/pages/api/chess/token/[id].ts
@@ -1,15 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+import { createClient } from '@supabase/supabase-js';
 import { BigNumber } from 'ethers';
 import { createPublicClient, http } from 'viem';
 import { mainnet } from 'viem/chains';
 
 import { idSchema } from '@/lib/schemas';
-import { supabaseAdmin } from '@/lib/services/supabase';
 import type { ChessNFTMetadata } from '@/lib/types/chess';
 import { validateQuery } from '@/lib/utils';
 
-export const publicClient = createPublicClient({
+const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_KEY,
+);
+
+const publicClient = createPublicClient({
   chain: mainnet,
   transport: http(),
 });

--- a/pages/api/chess/token/[id].ts
+++ b/pages/api/chess/token/[id].ts
@@ -82,7 +82,8 @@ export default async function handler(
 
   // Overwrite `animation_url` to proxied version on our server to accomodate
   // marketplaces' CSPs.
-  metadata.animation_url = `https://fiveoutofnine.com/api/chess/asset/${id}`;
+  //metadata.animation_url = `https://fiveoutofnine.com/api/chess/asset/${id}`;
+  metadata.animation_url = `https://www-git-chess-nft-tokenuri-fiveoutofnine.vercel.app/api/chess/asset/${id}`;
 
   // Cache response for 30 days.
   res.setHeader('cache-control', 'public, s-maxage=2592000');

--- a/pages/api/chess/token/[id].ts
+++ b/pages/api/chess/token/[id].ts
@@ -82,8 +82,7 @@ export default async function handler(
 
   // Overwrite `animation_url` to proxied version on our server to accomodate
   // marketplaces' CSPs.
-  //metadata.animation_url = `https://fiveoutofnine.com/api/chess/asset/${id}`;
-  metadata.animation_url = `https://www-git-chess-nft-tokenuri-fiveoutofnine.vercel.app/api/chess/asset/${id}`;
+  metadata.animation_url = `https://fiveoutofnine.com/api/chess/asset/${id}`;
 
   // Cache response for 30 days.
   res.setHeader('cache-control', 'public, s-maxage=2592000');

--- a/pages/api/chess/token/[id].ts
+++ b/pages/api/chess/token/[id].ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { BigNumber } from 'ethers';
+import { createPublicClient, http } from 'viem';
+import { mainnet } from 'viem/chains';
+
+import { idSchema } from '@/lib/schemas';
+import { supabaseAdmin } from '@/lib/services/supabase';
+import type { ChessNFTMetadata } from '@/lib/types/chess';
+import { validateQuery } from '@/lib/utils';
+
+export const publicClient = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+});
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ChessNFTMetadata | Error>,
+) {
+  const { id } = validateQuery(idSchema, req.query);
+
+  // First, attempt to fetch the metadata from Supabase.
+  const { data, status, error } = await supabaseAdmin
+    .from('chess_nft_metadata')
+    .select('*')
+    .eq('id', id)
+    .returns<ChessNFTMetadata[]>();
+
+  let metadata: ChessNFTMetadata;
+  // If there is an error, or if the data is empty, or if there is no data,
+  // then attempt to fetch the metadata from Ethereum via the `_tokenURI`
+  // function.
+  if ((error && status !== 406) || (data && data.length === 0) || !data) {
+    try {
+      // Fetch metadata.
+      const tokenURI = await publicClient.readContract({
+        // fiveoutofnine Chess NFT contract
+        address: '0xB543F9043b387cE5B3d1F0d916E42D8eA2eBA2E0',
+        abi: [
+          {
+            inputs: [{ internalType: 'uint256', name: '_tokenId', type: 'uint256' }],
+            name: '_tokenURI',
+            outputs: [{ internalType: 'string', name: '', type: 'string' }],
+            stateMutability: 'view',
+            type: 'function',
+          },
+        ],
+        functionName: '_tokenURI',
+        args: [BigNumber.from(id)],
+      });
+      const tokenURIParsed = JSON.parse(
+        Buffer.from(tokenURI.substring(29), 'base64').toString(),
+      ) as ChessNFTMetadata;
+
+      metadata = {
+        id,
+        name: tokenURIParsed.name,
+        description: tokenURIParsed.description,
+        animation_url: tokenURIParsed.animation_url,
+        attributes: tokenURIParsed.attributes,
+      };
+    } catch (err) {
+      res.status(404).json({ name: 'Not found', message: 'Token is nonexistent.' });
+      return;
+    }
+
+    // Insert into Supabase.
+    const { error: upsertError } = await supabaseAdmin.from('chess_nft_metadata').upsert(metadata);
+    if (upsertError) {
+      res.status(500).json({ name: 'Internal server error', message: 'Something went wrong.' });
+      return;
+    }
+  } else {
+    metadata = data[0];
+  }
+
+  // Overwrite `animation_url` to proxied version on our server to accomodate
+  // marketplaces' CSPs.
+  metadata.animation_url = `https://fiveoutofnine.com/api/chess/asset/${id}`;
+
+  // Cache response for 30 days.
+  res.setHeader('cache-control', 'public, s-maxage=2592000');
+  res.status(200).json(metadata);
+}


### PR DESCRIPTION
Adds 2 endpoints relevant to the fiveoutofnine chess NFT ([`0xb543f9043b387ce5b3d1f0d916e42d8ea2eba2e0`](https://etherscan.io/address/0xb543f9043b387ce5b3d1f0d916e42d8ea2eba2e0)):
* `/api/chess/token/[id]`, which is intended to serve as the NFT's `tokenURI` function.
* `/api/chess/asset/[id]`, which is intended to serve as a proxy to displaying the NFT's image (`animation_url`) metadata as a proxy for marketplaces.

The primary motive for having the `tokenURI` response proxied through an off-chain server was so the corresponding image (in this case, the field returned by `animation_url`) was to bypass marketplace's CSPs.
> **Note** The contract is still generating all of the metadata 100% on-chain (you can view this via the `_tokenURI` function). In fact, if `baseURI` was set to an empty string, it'd directly return the result from `_tokenURI`. The API endpoints this PR adds just calls `_tokenURI`, stores the result in a database for faster/easier read access, then returns it.